### PR TITLE
Update Renovate config and bump Cyano dependency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/aves-maintainers)",
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/mycelium-maintainers)",
     "github>OneLiteFeatherNET/renovate:minestom"
   ],
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/aves-maintainers)",
+    "github>OneLiteFeatherNET/renovate:minestom"
   ],
   "labels": [
     "renovate"
   ],
   "packageRules": [
-    {
-      "matchPackageNames": ["net.minestom:minestom"],
-      "versioning": "regex:^(?<major>\\d{4})\\.(?<minor>\\d{2})\\.(?<patch>\\d{2})(?<prerelease>[a-zA-Z]?)-(?<build>[A-Za-z0-9._]+)$"
-    },
     {
       "matchUpdateTypes": ["major", "minor", "patch"],
       "automerge": true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
             version("adventure", "5.1.1")
             version("junit.bom", "6.0.3")
             version("mockito", "5.23.0")
-            version("cyano", "0.5.7")
+            version("cyano", "0.5.9")
             version("cyclonedx", "3.2.4")
 
             library("minestom","net.minestom", "minestom").versionRef("minestom")


### PR DESCRIPTION
## Summary
This PR updates the Renovate configuration to use shared presets from the OneLiteFeatherNET/renovate repository and bumps the Cyano dependency to a newer version.

## Key Changes
- **Renovate Configuration**: Replaced the generic `config:recommended` preset with custom presets (`default` and `minestom`) from the OneLiteFeatherNET/renovate repository for more tailored dependency management
- **Removed Custom Versioning Rule**: Deleted the custom regex versioning pattern for Minestom, as this is now handled by the shared `minestom` preset
- **Cyano Dependency**: Updated from version `0.5.7` to `0.5.9`

## Implementation Details
The Renovate configuration changes consolidate version management rules into shared presets, reducing duplication and improving maintainability. The Minestom versioning regex that was previously defined inline is now managed centrally in the shared preset configuration.

https://claude.ai/code/session_015r5WcaJYweHG9cjRdyyVst